### PR TITLE
Minor Fix About Deprecated Usages

### DIFF
--- a/src/trie.h
+++ b/src/trie.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <utility>
 #include <type_traits>
+#include <cstdint>
 
 namespace trie
 {

--- a/src/trie.h
+++ b/src/trie.h
@@ -248,7 +248,7 @@ template <typename ValueT>
 struct ValueHolder
 {
 private:
-    std::auto_ptr<ValueT> value;
+    std::unique_ptr<ValueT> value;
 public:
     typedef ValueT value_type; /* Effective type */
 


### PR DESCRIPTION
This fork addresses the following issues:

- The type uint32_t, originally provided via the C header <stdint.h>, requires inclusion of the C++ header <cstdint> when compiling under C++11 and later standards.
- std::auto_ptr has been deprecated since C++11 and is no longer recommended for use. It has been replaced with std::unique_ptr.